### PR TITLE
Add usage example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/bin
 **/obj
 *.cache
+.idea

--- a/List.sln
+++ b/List.sln
@@ -4,6 +4,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ListLib", "ListLib\ListLib.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ListDemo", "ListDemo\ListDemo.csproj", "{1EF8DF65-00C6-4B24-95F8-F9DA9B237D95}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ListLib.Tests", "ListLib.Tests\ListLib.Tests.csproj", "{FD791DCB-7E20-454C-913A-3CA171C4B11B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{1EF8DF65-00C6-4B24-95F8-F9DA9B237D95}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1EF8DF65-00C6-4B24-95F8-F9DA9B237D95}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1EF8DF65-00C6-4B24-95F8-F9DA9B237D95}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD791DCB-7E20-454C-913A-3CA171C4B11B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD791DCB-7E20-454C-913A-3CA171C4B11B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD791DCB-7E20-454C-913A-3CA171C4B11B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD791DCB-7E20-454C-913A-3CA171C4B11B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/ListDemo/Program.cs
+++ b/ListDemo/Program.cs
@@ -1,1 +1,22 @@
-﻿Console.WriteLine("This project is a demo for 'ListLib' that contains a custom doubly linked list!");
+﻿using ListLib;
+
+Console.WriteLine("This project is a demo for 'ListLib' that contains a custom doubly linked list!");
+
+var lst = new DoublyLinkedList<int>();
+
+lst.Add(1);
+lst.Add(2);
+lst.Add(3);
+lst.AddFirst(4);
+
+foreach (var el in lst)
+{
+    Console.WriteLine(el);
+}
+
+Console.WriteLine("List contains 4: " + lst.Contains(4));
+
+Console.WriteLine("Actual list size: " + lst.Length);
+lst.Clear();
+Console.WriteLine("List cleared!");
+Console.WriteLine("Actual list size: " + lst.Length);

--- a/ListLib.Tests/DlsTests.cs
+++ b/ListLib.Tests/DlsTests.cs
@@ -1,0 +1,102 @@
+using Xunit;
+
+namespace ListLib.Tests;
+
+public class DlsTests
+{
+    [Fact]
+    public void AddElementsToDls()
+    {
+        var dls = new DoublyLinkedList<int>();
+        
+        dls.Add(1);
+        dls.Add(2);
+        dls.Add(3);
+        
+        Assert.Collection(dls,
+            el => Assert.Equal(1, el),
+            el => Assert.Equal(2, el),
+            el => Assert.Equal(3, el));
+    }
+
+    [Fact]
+    public void AddFirstElementToDls()
+    {
+        var dls = new DoublyLinkedList<int>()
+        {
+            1,
+            2,
+            3
+        };
+
+        dls.AddFirst(4);
+        
+        Assert.Collection(dls,
+            el => Assert.Equal(4, el),
+            el => Assert.Equal(1, el),
+            el => Assert.Equal(2, el),
+            el => Assert.Equal(3, el));
+    }
+
+    [Fact]
+    public void AddOnlyFirstElementToDls()
+    {
+        var dls = new DoublyLinkedList<int>();
+
+        dls.AddFirst(4);
+        dls.AddFirst(3);
+        dls.AddFirst(2);
+        dls.AddFirst(1);
+
+        Assert.Collection(dls,
+            el => Assert.Equal(1, el),
+            el => Assert.Equal(2, el),
+            el => Assert.Equal(3, el),
+            el => Assert.Equal(4, el));
+    }
+
+    [Fact]
+    public void DlsContainsElement()
+    {
+        var dls = new DoublyLinkedList<int>()
+        {
+            1,
+            2,
+            3
+        };
+
+        Assert.True(dls.Contains(1));
+        Assert.True(dls.Contains(2));
+        Assert.True(dls.Contains(3));
+    }
+
+    [Fact]
+    public void DlsEnumerateElements()
+    {
+        var dls = new DoublyLinkedList<int>()
+        {
+            1,
+            2,
+            3
+        };
+
+        var dslAsString = string.Join("", dls);
+        
+        Assert.Equal("123", dslAsString);
+    }
+
+    [Fact]
+    public void DlsClear()
+    {
+        var dls = new DoublyLinkedList<int>()
+        {
+            1,
+            2,
+            3
+        };
+
+        dls.Clear();
+        
+        Assert.Equal(0, dls.Length);
+    }
+}

--- a/ListLib.Tests/ListLib.Tests.csproj
+++ b/ListLib.Tests/ListLib.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\ListLib\ListLib.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Covered operations
- `Add`
- `AddFirst`
- `Contains`
- `Clear`

Tests coverage ~ 79% according to dotCoverage